### PR TITLE
Update import paths to new fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build_%:
 sha256sum:
 	cd $(BINDIR) && sha256sum $(TARGET)_* > $(TARGET).sha256sum
 
-PKG_LIST = $(shell go list ./... | grep -v github.com/wi1dcard/fingerproxy/pkg/http2)
+PKG_LIST = $(shell go list ./... | grep -v github.com/0x4D31/fingerproxy/pkg/http2)
 test:
 	@go test -v $(PKG_LIST)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/wi1dcard/fingerproxy"
+import "github.com/0x4D31/fingerproxy"
 
 func main() {
 	fingerproxy.Run()

--- a/example/echo-server/detail.go
+++ b/example/echo-server/detail.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/0x4D31/fingerproxy/pkg/ja4"
 	"github.com/dreadl0ck/tlsx"
 	"github.com/refraction-networking/utls/dicttls"
-	"github.com/wi1dcard/fingerproxy/pkg/ja4"
 )
 
 type ja3Detail tlsx.ClientHelloBasic

--- a/example/echo-server/main.go
+++ b/example/echo-server/main.go
@@ -9,8 +9,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/wi1dcard/fingerproxy/pkg/debug"
-	"github.com/wi1dcard/fingerproxy/pkg/proxyserver"
+	"github.com/0x4D31/fingerproxy/pkg/debug"
+	"github.com/0x4D31/fingerproxy/pkg/proxyserver"
 )
 
 var (

--- a/example/echo-server/response.go
+++ b/example/echo-server/response.go
@@ -3,10 +3,10 @@ package main
 import (
 	"log"
 
+	"github.com/0x4D31/fingerproxy/pkg/ja3"
+	"github.com/0x4D31/fingerproxy/pkg/ja4"
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
 	"github.com/dreadl0ck/tlsx"
-	"github.com/wi1dcard/fingerproxy/pkg/ja3"
-	"github.com/wi1dcard/fingerproxy/pkg/ja4"
-	"github.com/wi1dcard/fingerproxy/pkg/metadata"
 )
 
 // echoResponse is the HTTP response struct of this echo server

--- a/example/echo-server/server.go
+++ b/example/echo-server/server.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/wi1dcard/fingerproxy/pkg/metadata"
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
 )
 
 func echoServer(w http.ResponseWriter, req *http.Request) {

--- a/example/http2-fingerprint-dos-poc/main.go
+++ b/example/http2-fingerprint-dos-poc/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wi1dcard/fingerproxy"
+	"github.com/0x4D31/fingerproxy"
 	"golang.org/x/net/http2"
 )
 

--- a/example/ja3-raw/main.go
+++ b/example/ja3-raw/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"fmt"
 
+	"github.com/0x4D31/fingerproxy"
+	"github.com/0x4D31/fingerproxy/pkg/fingerprint"
+	"github.com/0x4D31/fingerproxy/pkg/ja3"
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
+	"github.com/0x4D31/fingerproxy/pkg/reverseproxy"
 	"github.com/dreadl0ck/tlsx"
-	"github.com/wi1dcard/fingerproxy"
-	"github.com/wi1dcard/fingerproxy/pkg/fingerprint"
-	"github.com/wi1dcard/fingerproxy/pkg/ja3"
-	"github.com/wi1dcard/fingerproxy/pkg/metadata"
-	"github.com/wi1dcard/fingerproxy/pkg/reverseproxy"
 )
 
 func main() {

--- a/example/ja3-sorted-extensions/main.go
+++ b/example/ja3-sorted-extensions/main.go
@@ -7,12 +7,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/0x4D31/fingerproxy"
+	"github.com/0x4D31/fingerproxy/pkg/fingerprint"
+	"github.com/0x4D31/fingerproxy/pkg/ja3"
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
+	"github.com/0x4D31/fingerproxy/pkg/reverseproxy"
 	"github.com/dreadl0ck/tlsx"
-	"github.com/wi1dcard/fingerproxy"
-	"github.com/wi1dcard/fingerproxy/pkg/fingerprint"
-	"github.com/wi1dcard/fingerproxy/pkg/ja3"
-	"github.com/wi1dcard/fingerproxy/pkg/metadata"
-	"github.com/wi1dcard/fingerproxy/pkg/reverseproxy"
 )
 
 func main() {

--- a/example/my-fingerprint/main.go
+++ b/example/my-fingerprint/main.go
@@ -5,10 +5,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wi1dcard/fingerproxy"
-	"github.com/wi1dcard/fingerproxy/pkg/fingerprint"
-	"github.com/wi1dcard/fingerproxy/pkg/metadata"
-	"github.com/wi1dcard/fingerproxy/pkg/reverseproxy"
+	"github.com/0x4D31/fingerproxy"
+	"github.com/0x4D31/fingerproxy/pkg/fingerprint"
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
+	"github.com/0x4D31/fingerproxy/pkg/reverseproxy"
 
 	utls "github.com/refraction-networking/utls"
 )

--- a/fingerproxy.go
+++ b/fingerproxy.go
@@ -13,13 +13,13 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/0x4D31/fingerproxy/pkg/certwatcher"
+	"github.com/0x4D31/fingerproxy/pkg/debug"
+	fp "github.com/0x4D31/fingerproxy/pkg/fingerprint"
+	"github.com/0x4D31/fingerproxy/pkg/proxyserver"
+	"github.com/0x4D31/fingerproxy/pkg/reverseproxy"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/wi1dcard/fingerproxy/pkg/certwatcher"
-	"github.com/wi1dcard/fingerproxy/pkg/debug"
-	fp "github.com/wi1dcard/fingerproxy/pkg/fingerprint"
-	"github.com/wi1dcard/fingerproxy/pkg/proxyserver"
-	"github.com/wi1dcard/fingerproxy/pkg/reverseproxy"
 )
 
 const logFlags = log.LstdFlags | log.Lshortfile | log.Lmsgprefix

--- a/flags.go
+++ b/flags.go
@@ -132,7 +132,7 @@ func parseFlags() {
 	flag.Parse()
 
 	if *flagVersion {
-		fmt.Fprintln(os.Stderr, "Fingerproxy - https://github.com/wi1dcard/fingerproxy")
+		fmt.Fprintln(os.Stderr, "Fingerproxy - https://github.com/0x4D31/fingerproxy")
 		fmt.Fprintf(os.Stderr, "Version: %s (%s)\n", BuildTag, BuildCommit)
 		os.Exit(0)
 	}

--- a/pkg/fingerprint/fingerprint.go
+++ b/pkg/fingerprint/fingerprint.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/0x4D31/fingerproxy/pkg/ja3"
+	"github.com/0x4D31/fingerproxy/pkg/ja4"
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
 	"github.com/dreadl0ck/tlsx"
-	"github.com/wi1dcard/fingerproxy/pkg/ja3"
-	"github.com/wi1dcard/fingerproxy/pkg/ja4"
-	"github.com/wi1dcard/fingerproxy/pkg/metadata"
 )
 
 var (

--- a/pkg/fingerprint/fingerprint_test.go
+++ b/pkg/fingerprint/fingerprint_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wi1dcard/fingerproxy/pkg/metadata"
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
 )
 
 func hexToBytes(t *testing.T, s string) []byte {

--- a/pkg/fingerprint/header_injector.go
+++ b/pkg/fingerprint/header_injector.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/wi1dcard/fingerproxy/pkg/metadata"
 )
 
 const defaultMetricsPrefix = "fingerproxy"

--- a/pkg/http2/server.go
+++ b/pkg/http2/server.go
@@ -48,7 +48,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wi1dcard/fingerproxy/pkg/metadata"
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
 	"golang.org/x/net/http/httpguts"
 	"golang.org/x/net/http2/hpack"
 )

--- a/pkg/ja4pcap/pcap.go
+++ b/pkg/ja4pcap/pcap.go
@@ -17,10 +17,10 @@ import (
 
 	"cmp"
 
+	"github.com/0x4D31/fingerproxy/pkg/ja4"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
-	"github.com/wi1dcard/fingerproxy/pkg/ja4"
 )
 
 type pcapClientHello struct {

--- a/pkg/proxyserver/proxyserver.go
+++ b/pkg/proxyserver/proxyserver.go
@@ -17,11 +17,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/0x4D31/fingerproxy/pkg/hack"
+	"github.com/0x4D31/fingerproxy/pkg/http2"
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/wi1dcard/fingerproxy/pkg/hack"
-	"github.com/wi1dcard/fingerproxy/pkg/http2"
-	"github.com/wi1dcard/fingerproxy/pkg/metadata"
 )
 
 const defaultMetricsPrefix = "fingerproxy"


### PR DESCRIPTION
## Summary
- update Go imports to `github.com/0x4D31/fingerproxy`
- fix Makefile path for testing

## Testing
- `go test ./...` *(fails: TestInjectHeader, TestPreserveHost, TestAppendForwardHeader)*

------
https://chatgpt.com/codex/tasks/task_e_68732d2d11448331a9cca8dd48b86f70