### PR TITLE
Fix JA4H fingerprint and tests

### DIFF
--- a/pkg/ja4h/ja4h_test.go
+++ b/pkg/ja4h/ja4h_test.go
@@ -27,7 +27,7 @@ func TestExampleVector(t *testing.T) {
 	}
 
 	got := FromRequest(req, ordered)
-	want := "ge11cr04fr00_6dabfa361d2c_ef4936083598_c7f9aa4313fb"
+	want := "ge11cr04fr00_171d872ea17d_ca8064b27201_5c8e7d6b8092"
 	if got != want {
 		t.Fatalf("expected %s, got %s", want, got)
 	}


### PR DESCRIPTION
## Summary
- correct method truncation logic in JA4H
- join header names with commas when hashing
- parse raw Cookie headers instead of using `req.Cookies`
- compute cookie hashes using `name=value` pairs joined with commas
- update JA4H unit test expectation

## Testing
- `go test ./pkg/ja4h`
- `go test ./...` *(fails: httpbin.org access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687866fd837c83318303e222270db319