### PR TITLE
Add JA4H test for multiple cookies

### DIFF
--- a/pkg/ja4h/ja4h_test.go
+++ b/pkg/ja4h/ja4h_test.go
@@ -32,3 +32,30 @@ func TestExampleVector(t *testing.T) {
 		t.Fatalf("expected %s, got %s", want, got)
 	}
 }
+
+func TestHTTP2MultipleCookiesNoAcceptLang(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req.ProtoMajor = 2
+	req.ProtoMinor = 0
+	req.Proto = "HTTP/2"
+	req.Host = "example.com"
+	req.Header.Set("Host", "example.com")
+	req.Header.Set("User-Agent", "curl/8.7.1")
+	req.Header.Set("Accept", "*/*")
+	req.Header.Add("Cookie", "SID=1")
+	req.Header.Add("Cookie", "SID=2; theme=dark")
+
+	ordered := []string{
+		"host",
+		"user-agent",
+		"accept",
+		"cookie",
+		"cookie",
+	}
+
+	got := FromRequest(req, ordered)
+	want := "ge20cn030000_042112399351_9d6f7e01e35f_09672c2b113f"
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- extend JA4H tests with an HTTP/2 case that has multiple Cookie headers and no Accept-Language

## Testing
- `go test ./pkg/ja4h -v`
- `go test ./...` *(fails: proxy error: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68786b4f6dc8833189d3bcf64988360f