### PR TITLE
Add JA4H header injector

### DIFF
--- a/fingerproxy.go
+++ b/fingerproxy.go
@@ -63,6 +63,7 @@ func DefaultHeaderInjectors() []reverseproxy.HeaderInjector {
 	return []reverseproxy.HeaderInjector{
 		fp.NewFingerprintHeaderInjector("X-JA3-Fingerprint", fp.JA3Fingerprint),
 		fp.NewFingerprintHeaderInjector("X-JA4-Fingerprint", fp.JA4Fingerprint),
+		fp.NewJA4HFingerprintHeaderInjector("X-JA4H-Fingerprint"),
 		fp.NewFingerprintHeaderInjector("X-HTTP2-Fingerprint", h2fp.HTTP2Fingerprint),
 	}
 }

--- a/pkg/fingerprint/ja4h_header_injector.go
+++ b/pkg/fingerprint/ja4h_header_injector.go
@@ -1,0 +1,49 @@
+package fingerprint
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/0x4D31/fingerproxy/pkg/ja4h"
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// JA4HFingerprintHeaderInjector injects the JA4H fingerprint into requests.
+type JA4HFingerprintHeaderInjector struct {
+	HeaderName                       string
+	FingerprintDurationSucceedMetric prometheus.Observer
+	FingerprintDurationErrorMetric   prometheus.Observer
+}
+
+// NewJA4HFingerprintHeaderInjector creates a header injector for JA4H.
+func NewJA4HFingerprintHeaderInjector(headerName string) *JA4HFingerprintHeaderInjector {
+	i := &JA4HFingerprintHeaderInjector{HeaderName: headerName}
+	if fingerprintDurationMetric != nil {
+		i.FingerprintDurationSucceedMetric = fingerprintDurationMetric.WithLabelValues("1", headerName)
+		i.FingerprintDurationErrorMetric = fingerprintDurationMetric.WithLabelValues("0", headerName)
+	}
+	return i
+}
+
+func (i *JA4HFingerprintHeaderInjector) GetHeaderName() string {
+	return i.HeaderName
+}
+
+func (i *JA4HFingerprintHeaderInjector) GetHeaderValue(req *http.Request) (string, error) {
+	data, ok := metadata.FromContext(req.Context())
+	if !ok {
+		return "", fmt.Errorf("failed to get context")
+	}
+
+	start := time.Now()
+	fp := ja4h.FromRequest(req, data.OrderedHTTP1Headers)
+	duration := time.Since(start)
+	vlogf("fingerprint duration: %s", duration)
+
+	if i.FingerprintDurationSucceedMetric != nil {
+		i.FingerprintDurationSucceedMetric.Observe(duration.Seconds())
+	}
+	return fp, nil
+}

--- a/pkg/fingerprint/ja4h_header_injector_test.go
+++ b/pkg/fingerprint/ja4h_header_injector_test.go
@@ -1,0 +1,44 @@
+package fingerprint
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/0x4D31/fingerproxy/pkg/metadata"
+)
+
+func TestJA4HHeaderInjector(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req.ProtoMajor = 1
+	req.ProtoMinor = 1
+	req.Host = "example.com"
+	req.Header.Set("Host", "example.com")
+	req.Header.Set("User-Agent", "curl/8.7.1")
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Accept-Language", "fr")
+	req.Header.Set("Cookie", "SID=123; theme=dark")
+	req.Header.Set("Referer", "https://example.com/start")
+
+	ordered := []string{
+		"host",
+		"user-agent",
+		"accept",
+		"accept-language",
+		"cookie",
+		"referer",
+	}
+
+	ctx, md := metadata.NewContext(req.Context())
+	md.OrderedHTTP1Headers = ordered
+	req = req.WithContext(ctx)
+
+	hj := NewJA4HFingerprintHeaderInjector("ja4h")
+	got, err := hj.GetHeaderValue(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "ge11cr04fr00_171d872ea17d_ca8064b27201_5c8e7d6b8092"
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- inject JA4H fingerprint header by default
- add JA4HFingerprintHeaderInjector implementation
- test JA4H header injector

## Testing
- `go test ./...` *(fails: unexpected end of JSON input)*

------
https://chatgpt.com/codex/tasks/task_e_68786da893b4833182e8f17afc7f8cb6