### PR TITLE
Record ordered HTTP/2 headers

### DIFF
--- a/pkg/http2/server.go
+++ b/pkg/http2/server.go
@@ -1631,6 +1631,15 @@ func (sc *serverConn) processFrame(f Frame) error {
 				headers = append(headers, metadata.HeaderField(h))
 			}
 			md.HTTP2Frames.Headers = headers
+			if len(md.OrderedHTTP2Headers) == 0 {
+				for _, h := range f.Fields {
+					if strings.HasPrefix(h.Name, ":") {
+						continue
+					}
+					lower, _ := asciiToLower(h.Name)
+					md.OrderedHTTP2Headers = append(md.OrderedHTTP2Headers, lower)
+				}
+			}
 			if f.HasPriority() {
 				md.HTTP2Frames.Priorities = append(md.HTTP2Frames.Priorities,
 					metadata.Priority{

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -26,4 +26,9 @@ type Metadata struct {
 	// were received for HTTP/1.x connections. Names are lower-case and
 	// may appear multiple times if the client sent duplicates.
 	OrderedHTTP1Headers []string
+
+	// OrderedHTTP2Headers lists request header names in the order they
+	// were received for HTTP/2 connections. Names are lower-case and
+	// exclude pseudo headers.
+	OrderedHTTP2Headers []string
 }


### PR DESCRIPTION
## Summary
- store HTTP/2 header order in metadata
- collect header names in server when first HEADERS frame arrives

## Testing
- `go test ./pkg/fingerprint ./pkg/http2 -run . -short -v`


------
https://chatgpt.com/codex/tasks/task_e_68799e4787208331823023a59cec133e