### PR TITLE
Refactor HTTP/2 header order handling

### DIFF
--- a/pkg/fingerprint/ja4h_header_injector.go
+++ b/pkg/fingerprint/ja4h_header_injector.go
@@ -38,8 +38,8 @@ func (i *JA4HFingerprintHeaderInjector) GetHeaderValue(req *http.Request) (strin
 	}
 
 	ordered := data.OrderedHTTP1Headers
-	if req.ProtoMajor == 2 {
-		ordered = data.OrderedHTTP2Headers
+	if len(ordered) == 0 {
+		ordered = data.HTTP2Frames.OrderedHeaders()
 	}
 
 	start := time.Now()

--- a/pkg/fingerprint/ja4h_header_injector_test.go
+++ b/pkg/fingerprint/ja4h_header_injector_test.go
@@ -56,17 +56,15 @@ func TestJA4HHeaderInjectorHTTP2(t *testing.T) {
 	req.Header.Set("Cookie", "SID=123; theme=dark")
 	req.Header.Set("Referer", "https://example.com/start")
 
-	ordered := []string{
-		"host",
-		"user-agent",
-		"accept",
-		"accept-language",
-		"cookie",
-		"referer",
-	}
-
 	ctx, md := metadata.NewContext(req.Context())
-	md.OrderedHTTP2Headers = ordered
+	md.HTTP2Frames.Headers = []metadata.HeaderField{
+		{Name: "host"},
+		{Name: "user-agent"},
+		{Name: "accept"},
+		{Name: "accept-language"},
+		{Name: "cookie"},
+		{Name: "referer"},
+	}
 	req = req.WithContext(ctx)
 
 	hj := NewJA4HFingerprintHeaderInjector("ja4h")
@@ -75,6 +73,39 @@ func TestJA4HHeaderInjectorHTTP2(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := "ge20cr04fr00_171d872ea17d_ca8064b27201_5c8e7d6b8092"
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}
+
+func TestJA4HHeaderInjectorHTTP2MultipleHeaders(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req.Proto = "HTTP/2.0"
+	req.ProtoMajor = 2
+	req.ProtoMinor = 0
+	req.Host = "example.com"
+	req.Header.Set("Host", "example.com")
+	req.Header.Set("User-Agent", "curl/8.7.1")
+	req.Header.Set("Accept", "*/*")
+	req.Header.Add("Cookie", "SID=1")
+	req.Header.Add("Cookie", "SID=2; theme=dark")
+
+	ctx, md := metadata.NewContext(req.Context())
+	md.HTTP2Frames.Headers = []metadata.HeaderField{
+		{Name: "host"},
+		{Name: "user-agent"},
+		{Name: "accept"},
+		{Name: "cookie"},
+		{Name: "cookie"},
+	}
+	req = req.WithContext(ctx)
+
+	hj := NewJA4HFingerprintHeaderInjector("ja4h")
+	got, err := hj.GetHeaderValue(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "ge20cn030000_042112399351_9d6f7e01e35f_09672c2b113f"
 	if got != want {
 		t.Fatalf("expected %s, got %s", want, got)
 	}

--- a/pkg/http2/server.go
+++ b/pkg/http2/server.go
@@ -1633,15 +1633,6 @@ func (sc *serverConn) processFrame(f Frame) error {
 				}
 				md.HTTP2Frames.Headers = headers
 			}
-			if len(md.OrderedHTTP2Headers) == 0 {
-				for _, h := range f.Fields {
-					if strings.HasPrefix(h.Name, ":") {
-						continue
-					}
-					lower, _ := asciiToLower(h.Name)
-					md.OrderedHTTP2Headers = append(md.OrderedHTTP2Headers, lower)
-				}
-			}
 			if f.HasPriority() {
 				md.HTTP2Frames.Priorities = append(md.HTTP2Frames.Priorities,
 					metadata.Priority{

--- a/pkg/metadata/http2.go
+++ b/pkg/metadata/http2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"strings"
 )
 
 // https://github.com/golang/net/blob/5a444b4f2fe893ea00f0376da46aa5376c3f3e28/http2/http2.go#L112-L119
@@ -42,6 +43,20 @@ type HTTP2FingerprintingFrames struct {
 
 func (f *HTTP2FingerprintingFrames) String() string {
 	return f.Marshal(math.MaxUint)
+}
+
+// OrderedHeaders returns the HTTP/2 header names in the order they were
+// received. Pseudo headers (starting with a colon) are skipped. Header names
+// are lower-cased and duplicates are preserved.
+func (f *HTTP2FingerprintingFrames) OrderedHeaders() []string {
+	names := make([]string, 0, len(f.Headers))
+	for _, h := range f.Headers {
+		if len(h.Name) > 0 && h.Name[0] == ':' {
+			continue
+		}
+		names = append(names, strings.ToLower(h.Name))
+	}
+	return names
 }
 
 // TODO: add tests

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -26,9 +26,4 @@ type Metadata struct {
 	// were received for HTTP/1.x connections. Names are lower-case and
 	// may appear multiple times if the client sent duplicates.
 	OrderedHTTP1Headers []string
-
-	// OrderedHTTP2Headers lists request header names in the order they
-	// were received for HTTP/2 connections. Names are lower-case and
-	// exclude pseudo headers.
-	OrderedHTTP2Headers []string
 }


### PR DESCRIPTION
## Summary
- derive ordered HTTP/2 header names from captured frames
- expose `OrderedHeaders` helper on `HTTP2FingerprintingFrames`
- remove duplicated `OrderedHTTP2Headers` from metadata
- update JA4H header injector to use the new helper
- test HTTP/2 JA4H fingerprinting with duplicate headers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6879b4722a148331b5922fc424fbb3a6