### PR TITLE
Implement Metadata OrderedHeaders

### DIFF
--- a/pkg/fingerprint/ja4h_header_injector.go
+++ b/pkg/fingerprint/ja4h_header_injector.go
@@ -37,10 +37,7 @@ func (i *JA4HFingerprintHeaderInjector) GetHeaderValue(req *http.Request) (strin
 		return "", fmt.Errorf("failed to get context")
 	}
 
-	ordered := data.OrderedHTTP1Headers
-	if len(ordered) == 0 {
-		ordered = data.HTTP2Frames.OrderedHeaders()
-	}
+	ordered := data.OrderedHeaders()
 
 	start := time.Now()
 	fp := ja4h.FromRequest(req, ordered)

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -27,3 +27,13 @@ type Metadata struct {
 	// may appear multiple times if the client sent duplicates.
 	OrderedHTTP1Headers []string
 }
+
+// OrderedHeaders returns the HTTP header names in the order they were received.
+// If HTTP/1.x ordered headers are available they are returned directly;
+// otherwise the order is determined from captured HTTP/2 frames.
+func (m *Metadata) OrderedHeaders() []string {
+	if len(m.OrderedHTTP1Headers) > 0 {
+		return m.OrderedHTTP1Headers
+	}
+	return m.HTTP2Frames.OrderedHeaders()
+}

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -8,9 +8,6 @@ import (
 func TestMetadataOrderedHeadersHTTP1(t *testing.T) {
 	md := &Metadata{
 		OrderedHTTP1Headers: []string{"host", "user-agent"},
-		HTTP2Frames: HTTP2FingerprintingFrames{
-			Headers: []HeaderField{{Name: "accept"}},
-		},
 	}
 	got := md.OrderedHeaders()
 	want := []string{"host", "user-agent"}

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -1,0 +1,37 @@
+package metadata
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMetadataOrderedHeadersHTTP1(t *testing.T) {
+	md := &Metadata{
+		OrderedHTTP1Headers: []string{"host", "user-agent"},
+		HTTP2Frames: HTTP2FingerprintingFrames{
+			Headers: []HeaderField{{Name: "accept"}},
+		},
+	}
+	got := md.OrderedHeaders()
+	want := []string{"host", "user-agent"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestMetadataOrderedHeadersHTTP2(t *testing.T) {
+	md := &Metadata{
+		HTTP2Frames: HTTP2FingerprintingFrames{
+			Headers: []HeaderField{
+				{Name: ":method"},
+				{Name: "User-Agent"},
+				{Name: "accept"},
+			},
+		},
+	}
+	got := md.OrderedHeaders()
+	want := []string{"user-agent", "accept"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `Metadata.OrderedHeaders()`
- update JA4HFingerprintHeaderInjector to use the new method
- add tests for HTTP/1.x and HTTP/2 ordered headers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687b0a43b30c8331855016e042a7431a