### PR TITLE
Add HTTP/3 support to JA4H

### DIFF
--- a/pkg/ja4h/ja4h.go
+++ b/pkg/ja4h/ja4h.go
@@ -28,6 +28,8 @@ func buildA(req *http.Request, ordered []string) string {
 	// positions 3-4: HTTP version
 	version := "11"
 	switch req.Proto {
+	case "HTTP/3.0", "HTTP/3":
+		version = "30"
 	case "HTTP/2.0", "HTTP/2":
 		version = "20"
 	case "HTTP/1.1":

--- a/pkg/ja4h/ja4h_test.go
+++ b/pkg/ja4h/ja4h_test.go
@@ -59,3 +59,32 @@ func TestHTTP2MultipleCookiesNoAcceptLang(t *testing.T) {
 		t.Fatalf("expected %s, got %s", want, got)
 	}
 }
+
+func TestHTTP3ExampleVector(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req.ProtoMajor = 3
+	req.ProtoMinor = 0
+	req.Proto = "HTTP/3"
+	req.Host = "example.com"
+	req.Header.Set("Host", "example.com")
+	req.Header.Set("User-Agent", "curl/8.7.1")
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Accept-Language", "fr")
+	req.Header.Set("Cookie", "SID=123; theme=dark")
+	req.Header.Set("Referer", "https://example.com/start")
+
+	ordered := []string{
+		"host",
+		"user-agent",
+		"accept",
+		"accept-language",
+		"cookie",
+		"referer",
+	}
+
+	got := FromRequest(req, ordered)
+	want := "ge30cr04fr00_171d872ea17d_ca8064b27201_5c8e7d6b8092"
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- extend HTTP version detection in `buildA` to recognize HTTP/3
- add unit test covering HTTP/3 fingerprinting

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c540eaff88331bb67f36cd0ff8580