### PR TITLE
Handle early HTTP/1 disconnects in proxy listener

### DIFF
--- a/pkg/hack/http1_header_listener.go
+++ b/pkg/hack/http1_header_listener.go
@@ -1,6 +1,10 @@
 package hack
 
-import "net"
+import (
+	"errors"
+	"io"
+	"net"
+)
 
 // HTTP1HeaderListener wraps an existing listener and returns
 // connections that record HTTP/1.x header order.
@@ -10,15 +14,32 @@ func NewHTTP1HeaderListener(inner net.Listener) *HTTP1HeaderListener {
 	return &HTTP1HeaderListener{inner}
 }
 
+// Accept waits for and returns the next connection to the listener. It wraps
+// accepted connections with HTTP1HeaderConn to capture the order of HTTP/1.x
+// headers. If the client closes the connection before sending a complete
+// request (resulting in io.EOF or io.ErrUnexpectedEOF) or times out while
+// sending headers, the connection is discarded and Accept continues to wait for
+// the next one instead of returning an error up the stack which would stop the
+// HTTP server.
 func (l *HTTP1HeaderListener) Accept() (net.Conn, error) {
-	c, err := l.Listener.Accept()
-	if err != nil {
-		return nil, err
+	for {
+		c, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		hc, err := NewHTTP1HeaderConn(c)
+		if err != nil {
+			c.Close()
+			// Ignore errors where the client disconnects before
+			// completing the HTTP request or fails to send headers
+			// in time. These should not bring down the HTTP
+			// server.
+			var ne net.Error
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || (errors.As(err, &ne) && ne.Timeout()) {
+				continue
+			}
+			return nil, err
+		}
+		return hc, nil
 	}
-	hc, err := NewHTTP1HeaderConn(c)
-	if err != nil {
-		c.Close()
-		return nil, err
-	}
-	return hc, nil
 }

--- a/pkg/hack/http1_header_listener_test.go
+++ b/pkg/hack/http1_header_listener_test.go
@@ -1,0 +1,43 @@
+package hack
+
+import (
+	"io"
+	"net"
+	"testing"
+)
+
+type fakeListener struct{ conns []net.Conn }
+
+func (l *fakeListener) Accept() (net.Conn, error) {
+	if len(l.conns) == 0 {
+		return nil, io.EOF
+	}
+	c := l.conns[0]
+	l.conns = l.conns[1:]
+	return c, nil
+}
+
+func (l *fakeListener) Close() error   { return nil }
+func (l *fakeListener) Addr() net.Addr { return nil }
+
+func TestHTTP1HeaderListenerAcceptSkipsEarlyClose(t *testing.T) {
+	client1, server1 := net.Pipe()
+	client1.Close()
+	client2, server2 := net.Pipe()
+	go func() {
+		io.WriteString(client2, "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	}()
+
+	fl := &fakeListener{conns: []net.Conn{server1, server2}}
+	hl := NewHTTP1HeaderListener(fl)
+	conn, err := hl.Accept()
+	if err != nil {
+		t.Fatalf("Accept returned error: %v", err)
+	}
+	hc := conn.(*HTTP1HeaderConn)
+	if len(hc.OrderedHeaders()) == 0 {
+		t.Fatalf("expected headers to be captured")
+	}
+	conn.Close()
+	client2.Close()
+}


### PR DESCRIPTION
## Summary
- prevent `panic: EOF` by ignoring incomplete HTTP/1 connections
- add regression test for `HTTP1HeaderListener`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689438ca59c4833193a26fbd9803fa9a